### PR TITLE
Fix parsing of division operators and multi-character Qubit IDs

### DIFF
--- a/qsfw/circuitry/quantum_circuit.py
+++ b/qsfw/circuitry/quantum_circuit.py
@@ -59,23 +59,23 @@ class QuantumCircuit():
 	# 1-Qubit-Gate shortcuts
 
 	def add_identity_gate(self, qubit: str):
-		self.add_gate(IdentityGate(), (qubit))
+		self.add_gate(IdentityGate(), (qubit,))
 	def add_hadamard_gate(self, qubit: str):
-		self.add_gate(HGate(), (qubit))
+		self.add_gate(HGate(), (qubit,))
 	def add_pauliX_gate(self, qubit: str):
-		self.add_gate(PauliXGate(), (qubit))
+		self.add_gate(PauliXGate(), (qubit,))
 	def add_pauliY_gate(self, qubit: str):
-		self.add_gate(PauliYGate(), (qubit))
+		self.add_gate(PauliYGate(), (qubit,))
 	def add_pauliZ_gate(self, qubit: str):
-		self.add_gate(PauliZGate(), (qubit))
+		self.add_gate(PauliZGate(), (qubit,))
 	def add_phase_gate(self, qubit: str, angle: float):
-		self.add_gate(PhaseGate(angle), (qubit))
+		self.add_gate(PhaseGate(angle), (qubit,))
 	def add_sphase_gate(self, qubit: str):
-		self.add_gate(SPhaseGate(), (qubit))
+		self.add_gate(SPhaseGate(), (qubit,))
 	def add_tphase_gate(self, qubit: str):
-		self.add_gate(TPhaseGate(), (qubit))
+		self.add_gate(TPhaseGate(), (qubit,))
 	def add_measurement_gate(self, qubit):
-		self.add_gate(Measurement(), (qubit))
+		self.add_gate(Measurement(), (qubit,))
 
 	# 2-Qubit-Gate shortcuts
 

--- a/qsfw/scripting/lexer.py
+++ b/qsfw/scripting/lexer.py
@@ -54,7 +54,7 @@ class QSLexer():
 						tokens.append(IntegerLiteral(num_lit))
 					else:
 						tokens.append(FloatLiteral(num_lit))
-				elif c == '/':													# Comments
+				elif c == '/':
 					next = it.next()
 					if next == '/': # comment until end of line
 						c = it.next()
@@ -66,14 +66,14 @@ class QSLexer():
 						while not (c == '*' and next == '/'):
 							c = next
 							next = it.next()
+					else:													# Divison operator
+						tokens.append(DivOperator())
 				elif c == "+":													# Addition operator
 					tokens.append(PlusOperator())
 				elif c == "-":													# Subtraction operator
 					tokens.append(MinusOperator())
 				elif c == "*":													# Multiplication operator
 					tokens.append(MulOperator())
-				elif c == "/":													# Divison operator
-					tokens.append(DivOperator())
 				elif c.isalpha():												# Identifiers
 					ident = c
 					c = it.next()

--- a/qsfw/scripting/token.py
+++ b/qsfw/scripting/token.py
@@ -61,7 +61,7 @@ class MulOperator(MathOperator):
 		super().__init__('*')
 class DivOperator(MathOperator):
 	def __init__(self):
-		super().__init__('+')
+		super().__init__('/')
 class Identifier(Token):
 	def __init__(self, id: str):
 		self.content = id


### PR DESCRIPTION
Greetings @jonasjelonek,<br><br>

When a command like `cphase('q1', 'q0', pi / 2);` is parsed, the division operator gets ignored, resulting in the following error: `ValueError: Unknown function : pi2`
1dfda7f fixes some unreachable code and a typo for parsing those division operators.<br><br>

When applying a 1-Qubit-Gate to a qubit with a multi-character ID (e.g., `hadamard('q0');`), an AssertionError occurs.
7539534 adds a comma for those 1-Qubit-Gates to create and pass the intended tuple rather than the qubit ID string.<br><br>

[Here](https://github.com/jonasjelonek/qsfw/files/13199145/test.txt) is a simple example file where those errors occur.